### PR TITLE
✨ Mise en place des PodSecurityAdmission sur les namespaces clients

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -105,6 +105,10 @@ For specific exceptions, add another network policy.
 |  **CUSTOM_LABELS**                 | *Add custom labels to namespaces*    | `quota=managed,monitoring=true`  | `no   `     | -           |
 |  **DEFAULT_PERMISSION**            | *ClusterRole associated with default service account*    | `view`       | `no   `     | -           |
 |  **BLACKLIST**                     | *Ignore Project*                     | `my-project-dev`                 | `no   `     | -           |
+|  **PODSECURITYADMISSION_ENFORCEMENT**                     | *PodSecurityAdmission  Enforcement*                     | `restricted`                 | `no   `     | `baseline  `           |
+|  **PODSECURITYADMISSION_WARNING**                     | *PodSecurityAdmission Warning*                     | `restricted`                 | `no   `     | `restricted  `           |
+|  **PODSECURITYADMISSION_AUDIT**                     | *PodSecurityAdmission Audit*                     | `restricted`                 | `no   `     | `restricted  `           |
+|  **PRIVILEGED_NAMESPACES**                     | *Namespaces allowed to use privileged annotation*                     | `native-development`                 | `no   `     | -           |
 
 ## Versioning
  

--- a/internal/services/provisionner.go
+++ b/internal/services/provisionner.go
@@ -481,10 +481,13 @@ func updateExistingNamespace(project *v12.Project, api v13.CoreV1Interface) erro
 func generateNamespaceLabels(project *v12.Project) (labels map[string]string) {
 
 	defaultLabels := map[string]string{
-		"name":        project.Name,
-		"type":        "customer",
-		"creator":     "kubi",
-		"environment": project.Spec.Environment,
+		"name":                               project.Name,
+		"type":                               "customer",
+		"creator":                            "kubi",
+		"environment":                        project.Spec.Environment,
+		"pod-security.kubernetes.io/enforce": utils.Config.PodSecurityAdmissionEnforcement,
+		"pod-security.kubernetes.io/warn":    utils.Config.PodSecurityAdmissionWarning,
+		"pod-security.kubernetes.io/audit":   utils.Config.PodSecurityAdmissionAudit,
 	}
 
 	return utils.Union(defaultLabels, utils.Config.CustomLabels)

--- a/internal/services/provisionner.go
+++ b/internal/services/provisionner.go
@@ -485,7 +485,7 @@ func generateNamespaceLabels(project *v12.Project) (labels map[string]string) {
 		"type":                               "customer",
 		"creator":                            "kubi",
 		"environment":                        project.Spec.Environment,
-		"pod-security.kubernetes.io/enforce": utils.Config.PodSecurityAdmissionEnforcement,
+		"pod-security.kubernetes.io/enforce": utils.IsInPrivilegedNamespacesList(project.Name),
 		"pod-security.kubernetes.io/warn":    utils.Config.PodSecurityAdmissionWarning,
 		"pod-security.kubernetes.io/audit":   utils.Config.PodSecurityAdmissionAudit,
 	}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -99,6 +99,10 @@ func MakeConfig() (*types.Config, error) {
 	ldapUserFilter := getEnv("LDAP_USERFILTER", "(cn=%s)")
 	tenant := strings.ToLower(getEnv("TENANT", KubiTenantUndeterminable))
 
+	podSecurityAdmissionEnforcement := strings.ToLower(getEnv("PODSECURITYADMISSION_ENFORCEMENT", PodSecurityAdmissionEnforcement))
+	podSecurityAdmissionWarning := strings.ToLower(getEnv("PODSECURITYADMISSION_WARNING", PodSecurityAdmissionWarning))
+	podSecurityAdmissionAudit := strings.ToLower(getEnv("PODSECURITYADMISSION_AUDIT", PodSecurityAdmissionAudit))
+
 	ldapConfig := types.LdapConfig{
 		UserBase:             os.Getenv("LDAP_USERBASE"),
 		GroupBase:            os.Getenv("LDAP_GROUPBASE"),
@@ -122,22 +126,25 @@ func MakeConfig() (*types.Config, error) {
 		Attributes:           []string{"givenName", "sn", "mail", "uid", "cn", "userPrincipalName"},
 	}
 	config := &types.Config{
-		Tenant:                  tenant,
-		Ldap:                    ldapConfig,
-		KubeCa:                  caEncoded,
-		KubeCaText:              string(kubeCA),
-		KubeToken:               string(kubeToken),
-		PublicApiServerURL:      getEnv("PUBLIC_APISERVER_URL", ""),
-		ApiServerTLSConfig:      *tlsConfig,
-		TokenLifeTime:           getEnv("TOKEN_LIFETIME", "4h"),
-		ExtraTokenLifeTime:      getEnv("EXTRA_TOKEN_LIFETIME", "720h"),
-		Locator:                 getEnv("LOCATOR", KubiLocatorIntranet),
-		NetworkPolicy:           networkpolicyEnabled,
-		CustomLabels:            customLabels,
-		DefaultPermission:       getEnv("DEFAULT_PERMISSION", ""),
-		Blacklist:               strings.Split(getEnv("BLACKLIST", ""), ","),
-		Whitelist:               whitelist,
-		BlackWhitelistNamespace: getEnv("BLACK_WHITELIST_NAMESPACE", "default"),
+		Tenant:                          tenant,
+		PodSecurityAdmissionEnforcement: podSecurityAdmissionEnforcement,
+		PodSecurityAdmissionWarning:     podSecurityAdmissionWarning,
+		PodSecurityAdmissionAudit:       podSecurityAdmissionAudit,
+		Ldap:                            ldapConfig,
+		KubeCa:                          caEncoded,
+		KubeCaText:                      string(kubeCA),
+		KubeToken:                       string(kubeToken),
+		PublicApiServerURL:              getEnv("PUBLIC_APISERVER_URL", ""),
+		ApiServerTLSConfig:              *tlsConfig,
+		TokenLifeTime:                   getEnv("TOKEN_LIFETIME", "4h"),
+		ExtraTokenLifeTime:              getEnv("EXTRA_TOKEN_LIFETIME", "720h"),
+		Locator:                         getEnv("LOCATOR", KubiLocatorIntranet),
+		NetworkPolicy:                   networkpolicyEnabled,
+		CustomLabels:                    customLabels,
+		DefaultPermission:               getEnv("DEFAULT_PERMISSION", ""),
+		Blacklist:                       strings.Split(getEnv("BLACKLIST", ""), ","),
+		Whitelist:                       whitelist,
+		BlackWhitelistNamespace:         getEnv("BLACK_WHITELIST_NAMESPACE", "default"),
 	}
 
 	err := validation.ValidateStruct(config,

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -142,6 +142,7 @@ func MakeConfig() (*types.Config, error) {
 		NetworkPolicy:                   networkpolicyEnabled,
 		CustomLabels:                    customLabels,
 		DefaultPermission:               getEnv("DEFAULT_PERMISSION", ""),
+		PrivilegedNamespaces:            strings.Split(getEnv("PRIVILEGED_NAMESPACES", ""), ","),
 		Blacklist:                       strings.Split(getEnv("BLACKLIST", ""), ","),
 		Whitelist:                       whitelist,
 		BlackWhitelistNamespace:         getEnv("BLACK_WHITELIST_NAMESPACE", "default"),

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -51,7 +51,10 @@ const (
 	KubiEnvironmentDevelopment        = "development"
 	KubiEnvironmentShortDevelopment   = "dev"
 
-	KubiTenantUndeterminable = "undeterminable"
+	KubiTenantUndeterminable        = "undeterminable"
+	PodSecurityAdmissionEnforcement = "baseline"
+	PodSecurityAdmissionWarning     = "restricted"
+	PodSecurityAdmissionAudit       = "restricted"
 )
 
 var BlacklistedNamespaces = []string{

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -55,6 +55,8 @@ const (
 	PodSecurityAdmissionEnforcement = "baseline"
 	PodSecurityAdmissionWarning     = "restricted"
 	PodSecurityAdmissionAudit       = "restricted"
+
+	PodSecurityPrivileged = "privileged"
 )
 
 var BlacklistedNamespaces = []string{

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -1,6 +1,9 @@
 package utils
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 func IsEmpty(value string) bool {
 	return len(value) == 0
@@ -45,4 +48,14 @@ func Union(a map[string]string, b map[string]string) map[string]string {
 		a[k] = v
 	}
 	return a
+}
+
+func IsInPrivilegedNamespacesList(namespace string) string {
+	for _, nsItem := range Config.PrivilegedNamespaces {
+		if strings.Contains(nsItem, namespace) {
+			Log.Warn().Msgf("Namespace %v is labeled as privileged", namespace)
+			return PodSecurityPrivileged
+		}
+	}
+	return Config.PodSecurityAdmissionEnforcement
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -48,6 +48,7 @@ type Config struct {
 	NetworkPolicy                   bool
 	CustomLabels                    map[string]string
 	DefaultPermission               string
+	PrivilegedNamespaces            []string
 	Blacklist                       []string
 	BlackWhitelistNamespace         string
 	Whitelist                       bool

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -32,22 +32,25 @@ type LdapConfig struct {
 }
 
 type Config struct {
-	Tenant                  string
-	Ldap                    LdapConfig
-	PublicApiServerURL      string
-	KubeCa                  string
-	KubeCaText              string
-	KubeToken               string
-	ApiServerTLSConfig      tls.Config
-	TokenLifeTime           string
-	ExtraTokenLifeTime      string
-	Locator                 string
-	NetworkPolicy           bool
-	CustomLabels            map[string]string
-	DefaultPermission       string
-	Blacklist               []string
-	BlackWhitelistNamespace string
-	Whitelist               bool
+	PodSecurityAdmissionEnforcement string
+	PodSecurityAdmissionWarning     string
+	PodSecurityAdmissionAudit       string
+	Tenant                          string
+	Ldap                            LdapConfig
+	PublicApiServerURL              string
+	KubeCa                          string
+	KubeCaText                      string
+	KubeToken                       string
+	ApiServerTLSConfig              tls.Config
+	TokenLifeTime                   string
+	ExtraTokenLifeTime              string
+	Locator                         string
+	NetworkPolicy                   bool
+	CustomLabels                    map[string]string
+	DefaultPermission               string
+	Blacklist                       []string
+	BlackWhitelistNamespace         string
+	Whitelist                       bool
 }
 
 // Note: struct fields must be public in order for unmarshal to


### PR DESCRIPTION
Dans l'objectif de remplacer les podSecurityPolicy en prévision du passage en Kubernetes 1.26, il est nécessaire de mettre en place les nouvelles règles de sécurité.

A ce jour, en lien avec cette documentation : URL://pages/viewpage.action?pageId=228069521 

Nous mettons en place par défaut un enforce sur la policy "baseline", avec un warning emis dès lors que l'applicatif ne respecte pas la policy "restricted" et réalisons par défaut l'émission d'un event d'audit lorsque la policy ne respecte pas le niveau "restricted". 

L'objectif est d'effectuer une bascule en souplesse des projets clients ne respectant pas en totalité la règle restricted (en rapport avec la manière dont sont run les applications sur les clusters). 

Dans un premier temps, les projets pourront se voir autoriser des droits plus importants, mais l'objectif est de les prévenir que ces actions ne respectent pas les best-practices.