### PR TITLE
✏️ Fix Status Field into Kubi CRD

### DIFF
--- a/deployments/kube-crds.yml
+++ b/deployments/kube-crds.yml
@@ -13,6 +13,11 @@ spec:
         openAPIV3Schema:
           type: object
           properties:
+            status:
+              properties:
+                Name:
+                  type: string
+              type: object
             spec:
               type: object
               properties:


### PR DESCRIPTION
Ce fix est nécessaire pour que la status soit mis à jour lors de la création des projets. Actuellement le code de l'opérateur ne fait pas usage de la subresource status.

Pour que les status se mettent à jour à la suite de cette modification, les projets doivent etre supprimés et il suffit alors de relancer l'opérateur. Cela n'a aucun impact.