### PR TITLE
Set goreleaser version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.24.0
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
         if: github.event_name != 'pull_request'
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.24.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           distribution: goreleaser
-          version: v1.24.0
+          version: v2.5.0
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
         if: github.event_name != 'pull_request'
         with:
           distribution: goreleaser
-          version: v1.24.0
+          version: v2.5.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.24.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: v1.24.0
+          version: v2.5.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: kubi
 before:
   hooks:
@@ -105,10 +106,10 @@ dockers:
     - "ghcr.io/{{.Env.ORG}}/{{.ProjectName}}-webhook:{{.ShortCommit}}-amd64"
 
 snapshot:
-  name_template: "{{ .ShortCommit }}"
+  version_template: "{{ .ShortCommit }}"
 
 release:
   disable: true
 
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Without this, we use different versions of goreleaser in CI (github actions) and locally.

This is a problem, as it leads to discrepencies between github actions and our code: More recent versions of goreleaser have changed their config file syntax.

This fixes it by pinning the version in github actions.