### PR TITLE
Use goreleaser to push release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,37 +1,36 @@
-name: build
+name: pr
 
 on:
   push:
-    branches:
-      - 'master'
-    tags:
-      - 'v*'
   pull_request:
-    branches:
-      - 'master'
+
+env:
+  REGISTRY: ghcr.io
 
 jobs:
-  release:
-    name: Create Build
+  pr-tests:
+    name: Build and test images
     runs-on: ubuntu-latest
     strategy:
       matrix:
         component: [webhook, api, operator]
+        arch: [amd64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: cagip/kubi-${{ matrix.component }}
+
+      - name: Find current tag version
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        id: tags
+
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+
       - name: run tests
         run: make test
+
       - uses: goreleaser/goreleaser-action@v6
-        if: github.event_name == 'pull_request'
         with:
           distribution: goreleaser
           version: v2.5.0
@@ -40,18 +39,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG: ${{ github.REPOSITORY_OWNER }}
 
-      - name: Login to DockerHub
+      - name: Login to container registry
+        # Pull requests are targetting ca-gip/kubi and should not push an image
+        # Only push images for the fork's repository
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: goreleaser/goreleaser-action@v6
+      - name: Push development image into ghcr (packages)
+        # Pull requests are targetting ca-gip/kubi and should not push an image
+        # Only push images for the fork's repository
         if: github.event_name != 'pull_request'
-        with:
-          distribution: goreleaser
-          version: v2.5.0
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ github.REPOSITORY_OWNER }}/kubi-${{ matrix.component }}:${{ steps.tags.outputs.sha_short }}-${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,66 @@
-name: release
+name: Tag repo
 
 on:
   push:
     tags:
       - "*"
 
+env:
+  REGISTRY: docker.io
+
 permissions:
-  contents: write
+  contents: read
   
 jobs:
   release:
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [webhook, api, operator]
+        arch: [amd64]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
+
+      - name: Find current sha version
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        id: sha
+
+      - name: Find current tag version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        id: tag
+
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+
+      - name: run tests to ensure it is still releasable
+        run: make test
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: v2.5.0
-          args: release --clean
+          args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG: ${{ github.repository_owner }}
+          ORG: ${{ github.REPOSITORY_OWNER }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push development image into dockerhub
+        run: |
+          docker tag ghcr.io/cagip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }}
+          docker push ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }}
+          docker tag ghcr.io/cagip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} ca-gip/kubi-${{ matrix.component }}:${{ steps.tag.outputs.version }}
+          docker push ca-gip/kubi-${{ matrix.component }}:${{ steps.tag.outputs.version }}


### PR DESCRIPTION
Without this, goreleaser is broken, and does not properly push
neither on PR or on tag. This is due to a premature merge of
a previous MR.

This fixes it by ensuring the workflow works. It might need
a few iterations to test the tag system is working as expected.