### PR TITLE
Remove go-ozzo/ozzo-validation package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.23.3
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/gorilla/mux v1.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
@@ -20,7 +19,6 @@ require (
 )
 
 require (
-	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
-github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -22,8 +20,6 @@ github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
-github.com/go-ozzo/ozzo-validation v3.6.0+incompatible h1:msy24VGS42fKO9K1vLz82/GeYW1cILu7Nuuj1N3BBkE=
-github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/internal/utils/validationConfig.go
+++ b/internal/utils/validationConfig.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/url"
+	"strconv"
+
+	"github.com/ca-gip/kubi/pkg/types"
+)
+
+func validateBase64(s string) error {
+	if _, err := base64.StdEncoding.DecodeString(s); err != nil {
+		return errors.New("must be a valid base64 string")
+	}
+	return nil
+}
+
+func validateURL(s string) error {
+	if _, err := url.ParseRequestURI(s); err != nil {
+		return errors.New("must be a valid URL")
+	}
+	return nil
+}
+func validateLength(field string, min int, max int) error {
+	length := len(field)
+	if length < min || length > max {
+		return errors.New("length must be between " + strconv.Itoa(min) + " and " + strconv.Itoa(max) + " characters")
+	}
+	return nil
+}
+
+func validateLdapConfig(ldapConfig *types.LdapConfig) error {
+	if ldapConfig.UserBase == "" {
+		return errors.New("userBase is required")
+	}
+	if err := validateLength(ldapConfig.UserBase, 2, 200); err != nil {
+		return err
+	}
+	if ldapConfig.GroupBase == "" {
+		return errors.New("groupBase is required")
+	}
+	if err := validateLength(ldapConfig.GroupBase, 2, 200); err != nil {
+		return err
+	}
+	if ldapConfig.Host == "" {
+		return errors.New("host is required")
+	}
+	if err := validateURL(ldapConfig.Host); err != nil {
+		return err
+	}
+	if ldapConfig.BindDN == "" {
+		return errors.New("BindDN is required")
+	}
+	if err := validateLength(ldapConfig.BindDN, 2, 200); err != nil {
+		return err
+	}
+	if ldapConfig.BindPassword == "" {
+		return errors.New("BindPassword is required")
+	}
+	if err := validateLength(ldapConfig.BindPassword, 2, 200); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateConfig(config *types.Config) error {
+	if config.KubeToken == "" {
+		return errors.New("KubeToken is required")
+	}
+	if config.KubeCa == "" {
+		return errors.New("KubeCa is required")
+	}
+	if err := validateBase64(config.KubeCa); err != nil {
+		return err
+	}
+	if config.PublicApiServerURL == "" {
+		return errors.New("PublicApiServerURL is required")
+	}
+	if err := validateURL(config.PublicApiServerURL); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
with that, we are no longer dependent on ozzo packages which is an external package and is no longer maintained

without this, we are dependent on a external package that is very old