### PR TITLE
Fix incorrect name of releasable image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,8 @@ jobs:
 
       - name: Push development image into dockerhub
         run: |
-          docker tag ghcr.io/cagip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }}
+          docker images #display currently built images to ensure next calls will happen correctly
+          docker tag ghcr.io/ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }}
           docker push ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }}
-          docker tag ghcr.io/cagip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} ca-gip/kubi-${{ matrix.component }}:${{ steps.tag.outputs.version }}
+          docker tag ghcr.io/ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} ca-gip/kubi-${{ matrix.component }}:${{ steps.tag.outputs.version }}
           docker push ca-gip/kubi-${{ matrix.component }}:${{ steps.tag.outputs.version }}


### PR DESCRIPTION
Without this, the docker tag will fail with unknown image name.

This is a problem, as it breaks our releasing.

This fixes it by both listing the available images to tag but also removing the incorrect dash on the image names.