### PR TITLE
Remove dashes in the dockerhub repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Push development image into dockerhub
         run: |
           docker images #display currently built images to ensure next calls will happen correctly
-          docker tag ghcr.io/ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }}
-          docker push ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }}
-          docker tag ghcr.io/ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} ca-gip/kubi-${{ matrix.component }}:${{ steps.tag.outputs.version }}
-          docker push ca-gip/kubi-${{ matrix.component }}:${{ steps.tag.outputs.version }}
+          docker tag ghcr.io/ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} cagip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }}
+          docker push cagip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }}
+          docker tag ghcr.io/ca-gip/kubi-${{ matrix.component }}:${{ steps.sha.outputs.sha_short }}-${{ matrix.arch }} cagip/kubi-${{ matrix.component }}:${{ steps.tag.outputs.version }}
+          docker push cagip/kubi-${{ matrix.component }}:${{ steps.tag.outputs.version }}


### PR DESCRIPTION
We never used dashes in the docker hub repository. Yet, we have - in the code for releasing.

This is a problem, as this fails the publishing.

This fixes it by removing the dash, fixing the
previous commit 8aef4c9044d500b25a0b57587e4048c5452469e3.