### PR TITLE
Fix random ldap processing error

### DIFF
--- a/internal/ldap/membership.go
+++ b/internal/ldap/membership.go
@@ -39,7 +39,6 @@ func (c *LDAPClient) getMemberships(userDN string) (*LDAPMemberships, error) {
 		strings.ToUpper(c.ViewerGroupBase):      &m.ViewerAccess,
 		strings.ToUpper(c.ServiceGroupBase):     &m.ServiceAccess,
 		strings.ToUpper(c.OpsMasterGroupBase):   &m.CloudOpsAccess,
-		strings.ToUpper(c.GroupBase):            &m.ClusterGroupsAccess,
 	}
 
 	for _, entry := range entries {
@@ -54,6 +53,9 @@ func (c *LDAPClient) getMemberships(userDN string) (*LDAPMemberships, error) {
 			}
 		}
 		if !collected {
+			if strings.HasSuffix(upperDN, strings.ToUpper(c.GroupBase)){
+				m.ClusterGroupsAccess = append(m.ClusterGroupsAccess, entry)
+			}
 			slog.Info(fmt.Sprintf("Couldn't collect %+v", entry))
 			m.NonSpecificGroups = append(m.NonSpecificGroups, entry)
 		}


### PR DESCRIPTION
In order to assign cluster rights, kubi splits ldap groups into several categories (admin, project, customerops, etc). 
This operation is currently performed in a random order, the order in which the pair (key, value) is returned by the for_range loop. 
This led to erroneous behaviour in some cases, because the project category 'encompasses'  other "special" categories and can 'steal' group from those categories. 

This has been fixed by better managing such cases.