### PR TITLE
fix ldap groups processing

### DIFF
--- a/internal/ldap/membership.go
+++ b/internal/ldap/membership.go
@@ -53,11 +53,12 @@ func (c *LDAPClient) getMemberships(userDN string) (*LDAPMemberships, error) {
 			}
 		}
 		if !collected {
-			if strings.HasSuffix(upperDN, strings.ToUpper(c.GroupBase)){
+			if strings.HasSuffix(upperDN, strings.ToUpper(c.GroupBase)) {
 				m.ClusterGroupsAccess = append(m.ClusterGroupsAccess, entry)
+			} else {
+				slog.Info(fmt.Sprintf("Couldn't collect %+v", entry))
+				m.NonSpecificGroups = append(m.NonSpecificGroups, entry)
 			}
-			slog.Info(fmt.Sprintf("Couldn't collect %+v", entry))
-			m.NonSpecificGroups = append(m.NonSpecificGroups, entry)
 		}
 	}
 


### PR DESCRIPTION
Missing else conditions caused projects ldap groups to also be added to non-specific. 

This did not cause any bug, but is not the expected behaviour