### PR TITLE
Expose CN instead of DN

### DIFF
--- a/internal/ldap/membership_test.go
+++ b/internal/ldap/membership_test.go
@@ -39,7 +39,7 @@ func TestToGroupNames(t *testing.T) {
 					{DN: "cn=cluster1", Attributes: []*ldap.EntryAttribute{{Name: "cn", Values: []string{"cluster1"}}}},
 				},
 			},
-			expected: []string{"CN=ADMIN1", "CN=ADMIN2", "CN=APPOPS1", "CN=CLOUDOPS1", "CN=CLUSTER1", "CN=CUSTOMEROPS1", "CN=SERVICE1", "CN=VIEWER1"},
+			expected: []string{"ADMIN1", "ADMIN2", "APPOPS1", "CLOUDOPS1", "CLUSTER1", "CUSTOMEROPS1", "SERVICE1", "VIEWER1"},
 		},
 		{
 			name: "No groups",
@@ -71,7 +71,7 @@ func TestToGroupNames(t *testing.T) {
 				CloudOpsAccess:      []*ldap.Entry{},
 				ClusterGroupsAccess: []*ldap.Entry{},
 			},
-			expected: []string{"CN=ADMIN1", "CN=APPOPS1", "CN=VIEWER1"},
+			expected: []string{"ADMIN1", "APPOPS1", "VIEWER1"},
 		},
 	}
 

--- a/internal/services/rolebindings.go
+++ b/internal/services/rolebindings.go
@@ -3,8 +3,8 @@ package services
 import (
 	"context"
 	"fmt"
+	"strings"
 
-	"github.com/ca-gip/kubi/internal/ldap"
 	"github.com/ca-gip/kubi/internal/utils"
 	cagipv1 "github.com/ca-gip/kubi/pkg/apis/cagip/v1"
 	"github.com/prometheus/client_golang/prometheus"
@@ -115,17 +115,17 @@ func generateRoleBindings(project *cagipv1.Project, defaultServiceAccountRole st
 				{
 					APIGroup: "rbac.authorization.k8s.io",
 					Kind:     "Group",
-					Name:     ldap.NormalizeGroupName(utils.Config.Ldap.AppMasterGroupBase), // the equivalent of application master (appops)
+					Name:     strings.ToUpper(utils.Config.Ldap.AppMasterGroupBase), // the equivalent of application master (appops)
 				},
 				{
 					APIGroup: "rbac.authorization.k8s.io",
 					Kind:     "Group",
-					Name:     ldap.NormalizeGroupName(utils.Config.Ldap.CustomerOpsGroupBase), // the equivalent of application master (customerops)
+					Name:     strings.ToUpper(utils.Config.Ldap.CustomerOpsGroupBase), // the equivalent of application master (customerops)
 				},
 				{
 					APIGroup: "rbac.authorization.k8s.io",
 					Kind:     "Group",
-					Name:     ldap.NormalizeGroupName(utils.Config.Ldap.OpsMasterGroupBase), // the equivalent of ops master
+					Name:     strings.ToUpper(utils.Config.Ldap.OpsMasterGroupBase), // the equivalent of ops master
 				},
 			},
 		},
@@ -141,7 +141,7 @@ func generateRoleBindings(project *cagipv1.Project, defaultServiceAccountRole st
 				{
 					APIGroup: "rbac.authorization.k8s.io",
 					Kind:     "Group",
-					Name:     ldap.NormalizeGroupName(utils.Config.Ldap.ViewerGroupBase),
+					Name:     strings.ToUpper(utils.Config.Ldap.ViewerGroupBase),
 				},
 			},
 		},


### PR DESCRIPTION
Exposing the DN instead of the CN of the ldap groups is unnecessary. The CN value is more compact and sufficient to achieve the expected result.