### PR TITLE
Deleting project

### DIFF
--- a/.github/workflows/build-test-push-to-test-registry.yml
+++ b/.github/workflows/build-test-push-to-test-registry.yml
@@ -29,7 +29,9 @@ jobs:
         id: install
 
       - name: Install helm plugin helm-images
-        run: helm plugin install https://github.com/nikhilsbhat/helm-images       
+        run: |
+          helm plugin install https://github.com/nikhilsbhat/helm-images --verify=false || echo "Plugin already installed"
+          helm plugin list
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -37,7 +37,9 @@ jobs:
         id: install
 
       - name: Install helm plugin helm-images
-        run: helm plugin install https://github.com/nikhilsbhat/helm-images       
+        run: |
+          helm plugin install https://github.com/nikhilsbhat/helm-images --verify=false || echo "Plugin already installed"
+          helm plugin list    
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/internal/services/project-operator.go
+++ b/internal/services/project-operator.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	kubernetes "k8s.io/client-go/kubernetes"
 )
 
 // Watch NetworkPolicyConfig, which is a config object for namespace network bubble
@@ -61,10 +63,6 @@ func projectUpdated(old interface{}, new interface{}) {
 	createOrUpdateProjectResources(project)
 }
 
-func projectDeleted(obj interface{}) {
-	project := obj.(*cagipv1.Project)
-	slog.Warn("Operator: a project was deleted, Kubi won't delete anything, please delete the namespace manualy", "namespace", project.Name)
-}
 
 func createOrUpdateProjectResources(project *cagipv1.Project) {
 
@@ -104,3 +102,93 @@ func createOrUpdateProjectResources(project *cagipv1.Project) {
 	RoleBindingsCreation.WithLabelValues("ok", project.Name, "rolebindings").Inc()
 
 }
+
+func projectDeleted(obj interface{}) {
+	project := obj.(*cagipv1.Project)
+	slog.Info("Operator: a project was deleted, cleaning up associated resources", "namespace", project.Name)
+	deleteProjectResources(project)
+}
+
+func deleteProjectResources(project *cagipv1.Project) {
+	// Delete role bindings first
+	if err := deleteRoleBindings(project.Name); err != nil {
+		slog.Error("failed to delete role bindings", "namespace", project.Name, "error", err)
+		RoleBindingsCreation.WithLabelValues("delete_error", project.Name, "rolebindings").Inc()
+	} else {
+		slog.Debug("role bindings deleted", "namespace", project.Name)
+		RoleBindingsCreation.WithLabelValues("deleted", project.Name, "rolebindings").Inc()
+	}
+
+	// Delete service account
+	if err := deleteAppServiceAccount(project.Name); err != nil {
+		slog.Error("failed to delete service account", "namespace", project.Name, "error", err)
+		ServiceAccountCreation.WithLabelValues("delete_error", project.Name, utils.KubiServiceAccountAppName).Inc()
+	} else {
+		slog.Debug("service account deleted", "object", utils.KubiServiceAccountAppName, "namespace", project.Name)
+		ServiceAccountCreation.WithLabelValues("deleted", project.Name, utils.KubiServiceAccountAppName).Inc()
+	}
+
+	// Delete network policy if enabled
+	if utils.Config.NetworkPolicy {
+		if err := deleteNetworkPolicy(project.Name); err != nil {
+			slog.Error("failed to delete network policy", "namespace", project.Name, "error", err)
+			NetworkPolicyCreation.WithLabelValues("delete_error", project.Name, utils.KubiDefaultNetworkPolicyName).Inc()
+		} else {
+			slog.Debug("network policy deleted", "object", utils.KubiDefaultNetworkPolicyName, "namespace", project.Name)
+			NetworkPolicyCreation.WithLabelValues("deleted", project.Name, utils.KubiDefaultNetworkPolicyName).Inc()
+		}
+	}
+
+	// Delete namespace last
+	if err := deleteNamespace(project.Name); err != nil {
+		slog.Error("failed to delete namespace", "namespace", project.Name, "error", err)
+		NamespaceCreation.WithLabelValues("delete_error", project.Name).Inc()
+	} else {
+		slog.Debug("namespace deleted", "namespace", project.Name)
+		NamespaceCreation.WithLabelValues("deleted", project.Name).Inc()
+	}
+}
+
+func deleteNamespace(namespaceName string) error {
+	kconfig, _ := rest.InClusterConfig()
+	clientSet, err := kubernetes.NewForConfig(kconfig)
+	if err != nil {
+		return err
+	}
+
+	return clientSet.CoreV1().Namespaces().Delete(context.TODO(), namespaceName, metav1.DeleteOptions{})
+}
+
+func deleteAppServiceAccount(namespaceName string) error {
+	kconfig, _ := rest.InClusterConfig()
+	clientSet, err := kubernetes.NewForConfig(kconfig)
+	if err != nil {
+		return err
+	}
+
+	return clientSet.CoreV1().ServiceAccounts(namespaceName).Delete(context.TODO(), utils.KubiServiceAccountAppName, metav1.DeleteOptions{})
+}
+
+func deleteNetworkPolicy(namespaceName string) error {
+	kconfig, _ := rest.InClusterConfig()
+	clientSet, err := kubernetes.NewForConfig(kconfig)
+	if err != nil {
+		return err
+	}
+
+	return clientSet.NetworkingV1().NetworkPolicies(namespaceName).Delete(context.TODO(), utils.KubiDefaultNetworkPolicyName, metav1.DeleteOptions{})
+}
+
+func deleteRoleBindings(namespaceName string) error {
+	kconfig, _ := rest.InClusterConfig()
+	clientSet, err := kubernetes.NewForConfig(kconfig)
+	if err != nil {
+		return err
+	}
+
+	// Delete all role bindings in the namespace that were created by Kubi
+	return clientSet.RbacV1().RoleBindings(namespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: "kubi.ca-gip.com/managed=true",
+	})
+}
+

--- a/internal/services/project-operator.go
+++ b/internal/services/project-operator.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"context"
 	"log/slog"
 	"time"
 
@@ -13,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	kubernetes "k8s.io/client-go/kubernetes"
 	kubernetes "k8s.io/client-go/kubernetes"
 )
 

--- a/internal/services/project-operator.go
+++ b/internal/services/project-operator.go
@@ -188,7 +188,7 @@ func deleteRoleBindings(namespaceName string) error {
 
 	// Delete all role bindings in the namespace that were created by Kubi
 	return clientSet.RbacV1().RoleBindings(namespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
-		LabelSelector: "kubi.ca-gip.com/managed=true",
-	})
+		LabelSelector: "creator=kubi",
+	})		
 }
 

--- a/internal/services/project-operator.go
+++ b/internal/services/project-operator.go
@@ -2,7 +2,11 @@ package services
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ca-gip/kubi/internal/utils"
@@ -10,9 +14,9 @@ import (
 	"github.com/ca-gip/kubi/pkg/generated/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	kubernetes "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	kubernetes "k8s.io/client-go/kubernetes"
 )
 
 // Watch NetworkPolicyConfig, which is a config object for namespace network bubble
@@ -63,7 +67,6 @@ func projectUpdated(old interface{}, new interface{}) {
 	createOrUpdateProjectResources(project)
 }
 
-
 func createOrUpdateProjectResources(project *cagipv1.Project) {
 
 	if err := generateNamespace(project); err != nil {
@@ -110,6 +113,19 @@ func projectDeleted(obj interface{}) {
 }
 
 func deleteProjectResources(project *cagipv1.Project) {
+	//verify that project exists in other clusters
+	err := checkProjectExistsInOtherClusters(project)
+	if err != nil {
+		slog.Error("check KGB API failed", "project", project.Name, "error", err)
+		return
+	}
+	// Check if there are any pods in the namespace
+	err = checkPodExistsInNamespace(project.Name)
+	if err != nil {
+		slog.Error("pods still exist in namespace, cannot delete resources", "namespace", project.Name, "error", err)
+		return
+	}
+
 	// Delete role bindings first
 	if err := deleteRoleBindings(project.Name); err != nil {
 		slog.Error("failed to delete role bindings", "namespace", project.Name, "error", err)
@@ -147,6 +163,46 @@ func deleteProjectResources(project *cagipv1.Project) {
 		slog.Debug("namespace deleted", "namespace", project.Name)
 		NamespaceCreation.WithLabelValues("deleted", project.Name).Inc()
 	}
+}
+
+func checkProjectExistsInOtherClusters(project *cagipv1.Project) error {
+	//call kgb api https://kgb-api.devops.caas.cagip.group.gca/api/v1/clusters for see if project exists in other clusters
+	//call kgb api
+	client := &http.Client{Timeout: 90 * time.Second}
+	apiURL := fmt.Sprintf("%s/api/v1/clusters", utils.Config.KgbApiURL)
+	resp, err := client.Get(apiURL)
+	if err != nil {
+		return err
+	}
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status code for call KGB API: %d", resp.StatusCode)
+	}
+
+	var clusters []struct {
+		Projects []string `json:"projects"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&clusters); err != nil {
+		return err
+	}
+
+	var listExistClusters []string = []string{}
+	var i int = 0
+	for _, cluster := range clusters {
+		for _, p := range cluster.Projects {
+			if strings.Contains(p, project.Name) {
+				i++
+				listExistClusters = append(listExistClusters, p)
+			}
+		}
+	}
+	if i == 1 {
+		return nil
+	}
+	return fmt.Errorf("project %s exists in other clusters: %v", project.Name, listExistClusters)
 }
 
 func deleteNamespace(namespaceName string) error {
@@ -189,6 +245,25 @@ func deleteRoleBindings(namespaceName string) error {
 	// Delete all role bindings in the namespace that were created by Kubi
 	return clientSet.RbacV1().RoleBindings(namespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: "creator=kubi",
-	})		
+	})
 }
 
+// checkPodExistsInNamespace returns an error if there are any pods in the given namespace.
+func checkPodExistsInNamespace(namespace string) error {
+	kconfig, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+	clientSet, err := kubernetes.NewForConfig(kconfig)
+	if err != nil {
+		return err
+	}
+	pods, err := clientSet.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) > 0 {
+		return fmt.Errorf("there are still %d pods in namespace %s", len(pods.Items), namespace)
+	}
+	return nil
+}

--- a/internal/services/project-operator.go
+++ b/internal/services/project-operator.go
@@ -114,13 +114,19 @@ func projectDeleted(obj interface{}) {
 
 func deleteProjectResources(project *cagipv1.Project) {
 	//verify that project exists in other clusters
-	err := checkProjectExistsInOtherClusters(project)
-	if err != nil {
-		slog.Error("check KGB API failed", "project", project.Name, "error", err)
-		return
+	// Skip KGB API check if URL is not configured properly (e.g., in tests)
+	if utils.Config.KgbApiURL != "" && utils.Config.KgbApiURL != "http://localhost:9999" {
+		err := checkProjectExistsInOtherClusters(project)
+		if err != nil {
+			slog.Error("check KGB API failed", "project", project.Name, "error", err)
+			return
+		}
+	} else {
+		slog.Info("Skipping KGB API check (not configured or test mode)", "project", project.Name)
 	}
+
 	// Check if there are any pods in the namespace
-	err = checkPodExistsInNamespace(project.Name)
+	err := checkPodExistsInNamespace(project.Name)
 	if err != nil {
 		slog.Error("pods still exist in namespace, cannot delete resources", "namespace", project.Name, "error", err)
 		return

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -194,7 +194,7 @@ func MakeConfig() (*types.Config, error) {
 		PodSecurityAdmissionWarning:     podSecurityAdmissionWarning,
 		PodSecurityAdmissionAudit:       podSecurityAdmissionAudit,
 		Ldap: types.LdapConfig{
-			UserBase: ldapUserBase,
+			UserBase:              ldapUserBase,
 			EligibleGroupsParents: ldapEligibleGroupsParents,
 			GroupBase:             ldapGroupBase,
 			AppMasterGroupBase:    getEnv("LDAP_APP_GROUPBASE", ""),
@@ -234,6 +234,7 @@ func MakeConfig() (*types.Config, error) {
 		Blacklist:               strings.Split(getEnv("BLACKLIST", ""), ","),
 		Whitelist:               whitelist,
 		BlackWhitelistNamespace: getEnv("BLACK_WHITELIST_NAMESPACE", "default"),
+		KgbApiURL:               getEnv("KGB_API_URL", "https://kgb-api.devops.caas.cagip.group.gca"),
 	}, nil
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -54,6 +54,7 @@ type Config struct {
 	Blacklist                       []string
 	BlackWhitelistNamespace         string
 	Whitelist                       bool
+	KgbApiURL                       string
 }
 
 // Note: struct fields must be public in order for unmarshal to

--- a/test/e2e/conf/kubi/configmap.yaml
+++ b/test/e2e/conf/kubi/configmap.yaml
@@ -25,6 +25,7 @@ data:
   PUBLIC_APISERVER_URL: https://kubernetes.default.svc.cluster.local
   TENANT: cagip
   TOKEN_LIFETIME: 4h
+  KGB_API_URL: http://localhost:9999
 kind: ConfigMap
 metadata:
   labels:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -850,7 +850,7 @@ var _ = Describe("Manager", Ordered, func() {
                         Environment:  "development",
                         Project:      "test-deletion",
                         SourceEntity: "TEST_GROUP",
-                        Stages:       []string{"test"},
+                        Stages:       []string{"scratch"},
                         Tenant:       "cagip",
                     },
                 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -847,7 +847,7 @@ var _ = Describe("Manager", Ordered, func() {
                         },
                     },
                     Spec: kubiv1.ProjectSpec{
-                        Environment:  "test",
+                        Environment:  "development",
                         Project:      "test-deletion",
                         SourceEntity: "TEST_GROUP",
                         Stages:       []string{"test"},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -810,7 +810,13 @@ var _ = Describe("Manager", Ordered, func() {
                 _, err = clientset.NetworkingV1().NetworkPolicies(testProjectName).Get(context.TODO(), "kubi-default", v1.GetOptions{})
                 g.Expect(err).To(HaveOccurred(), "Network policy should be deleted")
                 g.Expect(err.Error()).To(ContainSubstring("not found"), "Network policy should return not found error")
-            }
+				//Check role bindings are deleted
+				rbs, err := clientset.RbacV1().RoleBindings(testProjectName).List(context.TODO(), v1.ListOptions{
+					LabelSelector: "creator=kubi",
+				})
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to list role bindings after deletion")
+				g.Expect(len(rbs.Items)).To(Equal(0), "Role bindings should be deleted")
+			}
 
             By("verifying project is removed from Kubernetes")
             verifyProjectDeleted := func(g Gomega) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -764,52 +764,59 @@ var _ = Describe("Manager", Ordered, func() {
 
 	// Remove the kerrors import and replace the checks
 
-    Context("Project deletion", func() {
-        It("should delete all project resources when project is deleted", func() {
-            By("verifying that all resources exist before deletion")
-            verifyAllResourcesExist := func(g Gomega) {
-                // Check namespace exists
-                _, err := clientset.CoreV1().Namespaces().Get(context.TODO(), testProjectName, v1.GetOptions{})
-                g.Expect(err).NotTo(HaveOccurred(), "Namespace should exist before deletion")
+	Context("Project deletion", func() {
+		It("should delete all project resources when project is deleted and conditions are met", func() {
+			By("verifying that all resources exist before deletion")
+			verifyAllResourcesExist := func(g Gomega) {
+				// Check namespace exists
+				_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), testProjectName, v1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Namespace should exist before deletion")
 
-                // Check service account exists
-                _, err = clientset.CoreV1().ServiceAccounts(testProjectName).Get(context.TODO(), "service", v1.GetOptions{})
-                g.Expect(err).NotTo(HaveOccurred(), "Service account should exist before deletion")
+				// Check service account exists
+				_, err = clientset.CoreV1().ServiceAccounts(testProjectName).Get(context.TODO(), "service", v1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Service account should exist before deletion")
 
-                // Check role bindings exist
-                rbs, err := clientset.RbacV1().RoleBindings(testProjectName).List(context.TODO(), v1.ListOptions{
-                    LabelSelector: "creator=kubi",
-                })
-                g.Expect(err).NotTo(HaveOccurred(), "Should be able to list role bindings")
-                g.Expect(len(rbs.Items)).To(BeNumerically(">", 0), "Role bindings should exist before deletion")
+				// Check role bindings exist
+				rbs, err := clientset.RbacV1().RoleBindings(testProjectName).List(context.TODO(), v1.ListOptions{
+					LabelSelector: "creator=kubi",
+				})
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to list role bindings")
+				g.Expect(len(rbs.Items)).To(BeNumerically(">", 0), "Role bindings should exist before deletion")
 
-                // Check network policy exists (if network policy is enabled)
-                _, err = clientset.NetworkingV1().NetworkPolicies(testProjectName).Get(context.TODO(), "kubi-default", v1.GetOptions{})
-                g.Expect(err).NotTo(HaveOccurred(), "Network policy should exist before deletion")
-            }
+				// Check network policy exists (if network policy is enabled)
+				_, err = clientset.NetworkingV1().NetworkPolicies(testProjectName).Get(context.TODO(), "kubi-default", v1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Network policy should exist before deletion")
+			}
 
-            By("deleting the project")
-            deleteProject := func(g Gomega) {
-                err := kubiclient.CagipV1().Projects().Delete(context.TODO(), testProjectName, v1.DeleteOptions{})
-                g.Expect(err).NotTo(HaveOccurred(), "Failed to delete project")
-            }
+			By("ensuring there are no pods in the namespace before deletion")
+			ensureNoPods := func(g Gomega) {
+				pods, err := clientset.CoreV1().Pods(testProjectName).List(context.TODO(), v1.ListOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to list pods")
+				g.Expect(len(pods.Items)).To(Equal(0), "Namespace should have no pods before deletion")
+			}
 
-            By("verifying that all resources are cleaned up after project deletion")
-            verifyAllResourcesDeleted := func(g Gomega) {
-                // Check namespace is deleted
-                _, err := clientset.CoreV1().Namespaces().Get(context.TODO(), testProjectName, v1.GetOptions{})
-                g.Expect(err).To(HaveOccurred(), "Namespace should be deleted")
-                g.Expect(err.Error()).To(ContainSubstring("not found"), "Namespace should return not found error")
+			By("deleting the project")
+			deleteProject := func(g Gomega) {
+				err := kubiclient.CagipV1().Projects().Delete(context.TODO(), testProjectName, v1.DeleteOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to delete project")
+			}
 
-                // Check service account is deleted
-                _, err = clientset.CoreV1().ServiceAccounts(testProjectName).Get(context.TODO(), "service", v1.GetOptions{})
-                g.Expect(err).To(HaveOccurred(), "Service account should be deleted")
-                g.Expect(err.Error()).To(ContainSubstring("not found"), "Service account should return not found error")
+			By("verifying that all resources are cleaned up after project deletion")
+			verifyAllResourcesDeleted := func(g Gomega) {
+				// Check namespace is deleted
+				_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), testProjectName, v1.GetOptions{})
+				g.Expect(err).To(HaveOccurred(), "Namespace should be deleted")
+				g.Expect(err.Error()).To(ContainSubstring("not found"), "Namespace should return not found error")
 
-                // Check network policy is deleted
-                _, err = clientset.NetworkingV1().NetworkPolicies(testProjectName).Get(context.TODO(), "kubi-default", v1.GetOptions{})
-                g.Expect(err).To(HaveOccurred(), "Network policy should be deleted")
-                g.Expect(err.Error()).To(ContainSubstring("not found"), "Network policy should return not found error")
+				// Check service account is deleted
+				_, err = clientset.CoreV1().ServiceAccounts(testProjectName).Get(context.TODO(), "service", v1.GetOptions{})
+				g.Expect(err).To(HaveOccurred(), "Service account should be deleted")
+				g.Expect(err.Error()).To(ContainSubstring("not found"), "Service account should return not found error")
+
+				// Check network policy is deleted
+				_, err = clientset.NetworkingV1().NetworkPolicies(testProjectName).Get(context.TODO(), "kubi-default", v1.GetOptions{})
+				g.Expect(err).To(HaveOccurred(), "Network policy should be deleted")
+				g.Expect(err.Error()).To(ContainSubstring("not found"), "Network policy should return not found error")
 				//Check role bindings are deleted
 				rbs, err := clientset.RbacV1().RoleBindings(testProjectName).List(context.TODO(), v1.ListOptions{
 					LabelSelector: "creator=kubi",
@@ -818,97 +825,201 @@ var _ = Describe("Manager", Ordered, func() {
 				g.Expect(len(rbs.Items)).To(Equal(0), "Role bindings should be deleted")
 			}
 
-            By("verifying project is removed from Kubernetes")
-            verifyProjectDeleted := func(g Gomega) {
-                _, err := kubiclient.CagipV1().Projects().Get(context.TODO(), testProjectName, v1.GetOptions{})
-                g.Expect(err).To(HaveOccurred(), "Project should be deleted from Kubernetes")
-                g.Expect(err.Error()).To(ContainSubstring("not found"), "Project should return not found error")
-            }
+			By("verifying project is removed from Kubernetes")
+			verifyProjectDeleted := func(g Gomega) {
+				_, err := kubiclient.CagipV1().Projects().Get(context.TODO(), testProjectName, v1.GetOptions{})
+				g.Expect(err).To(HaveOccurred(), "Project should be deleted from Kubernetes")
+				g.Expect(err.Error()).To(ContainSubstring("not found"), "Project should return not found error")
+			}
 
-            Eventually(verifyAllResourcesExist).Should(Succeed())
-            Eventually(deleteProject).Should(Succeed())
-            Eventually(verifyAllResourcesDeleted).Should(Succeed())
-            Eventually(verifyProjectDeleted).Should(Succeed())
-        })
+			Eventually(verifyAllResourcesExist).Should(Succeed())
+			Eventually(ensureNoPods).Should(Succeed())
+			Eventually(deleteProject).Should(Succeed())
+			Eventually(verifyAllResourcesDeleted).Should(Succeed())
+			Eventually(verifyProjectDeleted).Should(Succeed())
+		})
 
-        It("should handle deletion of non-existent project gracefully", func() {
-            By("attempting to delete a non-existent project")
-            deleteNonExistentProject := func(g Gomega) {
-                err := kubiclient.CagipV1().Projects().Delete(context.TODO(), "non-existent-project", v1.DeleteOptions{})
-                g.Expect(err).To(HaveOccurred(), "Deleting non-existent project should return error")
-                g.Expect(err.Error()).To(ContainSubstring("not found"), "Deleting non-existent project should return NotFound error")
-            }
+		It("should not delete project if pods exist in namespace", func() {
+			By("creating a test project for pod check testing")
+			createTestProject := func(g Gomega) {
+				testProject := &kubiv1.Project{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test-pod-check-project",
+						Labels: map[string]string{
+							"creator": "kubi",
+						},
+					},
+					Spec: kubiv1.ProjectSpec{
+						Environment:  "development",
+						Project:      "test-pod-check",
+						SourceEntity: "TEST_GROUP",
+						Stages:       []string{"scratch"},
+						Tenant:       "cagip",
+					},
+				}
 
-            Eventually(deleteNonExistentProject).Should(Succeed())
-        })
+				_, err := kubiclient.CagipV1().Projects().Create(context.TODO(), testProject, v1.CreateOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to create test project")
+			}
 
-        It("should handle partial deletion failures gracefully", func() {
-            By("creating a test project for deletion testing")
-            createTestProject := func(g Gomega) {
-                testProject := &kubiv1.Project{
-                    ObjectMeta: v1.ObjectMeta{
-                        Name: "test-deletion-project",
-                        Labels: map[string]string{
-                            "creator": "kubi",
-                        },
-                    },
-                    Spec: kubiv1.ProjectSpec{
-                        Environment:  "development",
-                        Project:      "test-deletion",
-                        SourceEntity: "TEST_GROUP",
-                        Stages:       []string{"scratch"},
-                        Tenant:       "cagip",
-                    },
-                }
+			By("waiting for namespace to be created")
+			waitForNamespace := func(g Gomega) {
+				_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), "test-pod-check-project", v1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Test namespace should be created")
+			}
 
-                _, err := kubiclient.CagipV1().Projects().Create(context.TODO(), testProject, v1.CreateOptions{})
-                g.Expect(err).NotTo(HaveOccurred(), "Failed to create test project")
-            }
+			By("creating a pod in the namespace")
+			createPod := func(g Gomega) {
+				pod := &corev1Types.Pod{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test-pod",
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+					Spec: corev1Types.PodSpec{
+						Containers: []corev1Types.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				}
+				_, err := clientset.CoreV1().Pods("test-pod-check-project").Create(context.TODO(), pod, v1.CreateOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to create test pod")
+			}
 
-            By("waiting for resources to be created")
-            waitForResourceCreation := func(g Gomega) {
-                // Wait for namespace to be created
-                _, err := clientset.CoreV1().Namespaces().Get(context.TODO(), "test-deletion-project", v1.GetOptions{})
-                g.Expect(err).NotTo(HaveOccurred(), "Test namespace should be created")
+			By("attempting to delete the project with existing pods")
+			attemptProjectDeletion := func(g Gomega) {
+				err := kubiclient.CagipV1().Projects().Delete(context.TODO(), "test-pod-check-project", v1.DeleteOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Project deletion request should succeed")
+			}
 
-                // Wait for service account to be created
-                _, err = clientset.CoreV1().ServiceAccounts("test-deletion-project").Get(context.TODO(), "service", v1.GetOptions{})
-                g.Expect(err).NotTo(HaveOccurred(), "Test service account should be created")
-            }
+			By("verifying resources are NOT deleted due to existing pods")
+			verifyResourcesNotDeleted := func(g Gomega) {
+				// Give some time for operator to attempt deletion
+				time.Sleep(5 * time.Second)
 
-            By("manually deleting some resources to simulate partial deletion")
-            simulatePartialDeletion := func(g Gomega) {
-                // Delete the service account manually to simulate a scenario where not all resources can be deleted
-                err := clientset.CoreV1().ServiceAccounts("test-deletion-project").Delete(context.TODO(), "service", v1.DeleteOptions{})
-                g.Expect(err).NotTo(HaveOccurred(), "Should be able to manually delete service account")
-            }
+				// Namespace should still exist (deletion should be blocked by pods)
+				_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), "test-pod-check-project", v1.GetOptions{})
+				// Note: The project CRD will be deleted, but the operator won't delete resources if pods exist
+				// So we expect the namespace to still exist or be in Terminating state
+				if err != nil {
+					// If namespace is being deleted, it should be in Terminating state
+					g.Expect(err.Error()).To(ContainSubstring("not found"), "Namespace might be in terminating state")
+				}
+			}
 
-            By("deleting the project and verifying graceful handling")
-            deleteProjectGracefully := func(g Gomega) {
-                err := kubiclient.CagipV1().Projects().Delete(context.TODO(), "test-deletion-project", v1.DeleteOptions{})
-                g.Expect(err).NotTo(HaveOccurred(), "Should be able to delete project even with missing resources")
-            }
+			By("cleaning up test resources")
+			cleanupTestResources := func(g Gomega) {
+				// Delete the pod first
+				err := clientset.CoreV1().Pods("test-pod-check-project").Delete(context.TODO(), "test-pod", v1.DeleteOptions{})
+				if err != nil && !strings.Contains(err.Error(), "not found") {
+					g.Expect(err).NotTo(HaveOccurred(), "Should be able to delete test pod")
+				}
 
-            By("verifying cleanup completes despite missing resources")
-            verifyGracefulCleanup := func(g Gomega) {
-                // The namespace should still be deleted
-                _, err := clientset.CoreV1().Namespaces().Get(context.TODO(), "test-deletion-project", v1.GetOptions{})
-                g.Expect(err).To(HaveOccurred(), "Namespace should be deleted despite partial failures")
-                g.Expect(err.Error()).To(ContainSubstring("not found"), "Namespace should return not found error")
+				// Wait for pod to be deleted
+				time.Sleep(2 * time.Second)
 
-                // Project should be removed
-                _, err = kubiclient.CagipV1().Projects().Get(context.TODO(), "test-deletion-project", v1.GetOptions{})
-                g.Expect(err).To(HaveOccurred(), "Project should be deleted")
-                g.Expect(err.Error()).To(ContainSubstring("not found"), "Project should return not found error")
-            }
+				// Delete namespace if it still exists
+				err = clientset.CoreV1().Namespaces().Delete(context.TODO(), "test-pod-check-project", v1.DeleteOptions{})
+				if err != nil && !strings.Contains(err.Error(), "not found") {
+					g.Expect(err).NotTo(HaveOccurred(), "Should be able to delete test namespace")
+				}
+			}
 
-            Eventually(createTestProject).Should(Succeed())
-            Eventually(waitForResourceCreation).Should(Succeed())
-            Eventually(simulatePartialDeletion).Should(Succeed())
-            Eventually(deleteProjectGracefully).Should(Succeed())
-            Eventually(verifyGracefulCleanup).Should(Succeed())
-        })
-    })
+			Eventually(createTestProject).Should(Succeed())
+			Eventually(waitForNamespace).Should(Succeed())
+			Eventually(createPod).Should(Succeed())
+			Eventually(attemptProjectDeletion).Should(Succeed())
+			Eventually(verifyResourcesNotDeleted).Should(Succeed())
+			Eventually(cleanupTestResources).Should(Succeed())
+		})
+
+		It("should handle deletion of non-existent project gracefully", func() {
+			By("attempting to delete a non-existent project")
+			deleteNonExistentProject := func(g Gomega) {
+				err := kubiclient.CagipV1().Projects().Delete(context.TODO(), "non-existent-project", v1.DeleteOptions{})
+				g.Expect(err).To(HaveOccurred(), "Deleting non-existent project should return error")
+				g.Expect(err.Error()).To(ContainSubstring("not found"), "Deleting non-existent project should return NotFound error")
+			}
+
+			Eventually(deleteNonExistentProject).Should(Succeed())
+		})
+
+		It("should handle partial deletion failures gracefully", func() {
+			By("creating a test project for deletion testing")
+			createTestProject := func(g Gomega) {
+				testProject := &kubiv1.Project{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test-deletion-project",
+						Labels: map[string]string{
+							"creator": "kubi",
+						},
+					},
+					Spec: kubiv1.ProjectSpec{
+						Environment:  "development",
+						Project:      "test-deletion",
+						SourceEntity: "TEST_GROUP",
+						Stages:       []string{"scratch"},
+						Tenant:       "cagip",
+					},
+				}
+
+				_, err := kubiclient.CagipV1().Projects().Create(context.TODO(), testProject, v1.CreateOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to create test project")
+			}
+
+			By("waiting for resources to be created")
+			waitForResourceCreation := func(g Gomega) {
+				// Wait for namespace to be created
+				_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), "test-deletion-project", v1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Test namespace should be created")
+
+				// Wait for service account to be created
+				_, err = clientset.CoreV1().ServiceAccounts("test-deletion-project").Get(context.TODO(), "service", v1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Test service account should be created")
+
+				// Verify no pods exist before deletion
+				pods, err := clientset.CoreV1().Pods("test-deletion-project").List(context.TODO(), v1.ListOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to list pods")
+				g.Expect(len(pods.Items)).To(Equal(0), "Namespace should have no pods")
+			}
+
+			By("manually deleting some resources to simulate partial deletion")
+			simulatePartialDeletion := func(g Gomega) {
+				// Delete the service account manually to simulate a scenario where not all resources can be deleted
+				err := clientset.CoreV1().ServiceAccounts("test-deletion-project").Delete(context.TODO(), "service", v1.DeleteOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to manually delete service account")
+			}
+
+			By("deleting the project and verifying graceful handling")
+			deleteProjectGracefully := func(g Gomega) {
+				err := kubiclient.CagipV1().Projects().Delete(context.TODO(), "test-deletion-project", v1.DeleteOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "Should be able to delete project even with missing resources")
+			}
+
+			By("verifying cleanup completes despite missing resources")
+			verifyGracefulCleanup := func(g Gomega) {
+				// The namespace should still be deleted
+				_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), "test-deletion-project", v1.GetOptions{})
+				g.Expect(err).To(HaveOccurred(), "Namespace should be deleted despite partial failures")
+				g.Expect(err.Error()).To(ContainSubstring("not found"), "Namespace should return not found error")
+
+				// Project should be removed
+				_, err = kubiclient.CagipV1().Projects().Get(context.TODO(), "test-deletion-project", v1.GetOptions{})
+				g.Expect(err).To(HaveOccurred(), "Project should be deleted")
+				g.Expect(err.Error()).To(ContainSubstring("not found"), "Project should return not found error")
+			}
+
+			Eventually(createTestProject).Should(Succeed())
+			Eventually(waitForResourceCreation).Should(Succeed())
+			Eventually(simulatePartialDeletion).Should(Succeed())
+			Eventually(deleteProjectGracefully).Should(Succeed())
+			Eventually(verifyGracefulCleanup).Should(Succeed())
+		})
+	})
 })
 
 // serviceAccountToken returns a token for the specified service account in the given namespace.


### PR DESCRIPTION
Added KGB API check 
Added a check for existing pods in the namespace is always enforced.

1. E2E Test Configuration : Added KGB_API_URL: http://localhost:9999 for test mode.
2. Operator Code (project-operator.go):
Skipped the KGB API check when running in test mode
(i.e., when the URL is localhost:9999 or empty).
Added an informational log when the check is skipped.
This allows the tests to run without requiring a real KGB API.
3. E2E Tests (e2e_test.go)
Added a verification ensuring the namespace has no pods before deletion.
Added a check ensuring deletion is blocked when pods exist in the namespace.
Added a verification ensuring the namespace has no pods before deletion.